### PR TITLE
Replace deprecated create-release@v1

### DIFF
--- a/modules/profile/files/_github/workflows/tag_deploy_github-only.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_github-only.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -44,7 +45,6 @@ jobs:
           annotation="$(git for-each-ref "$GITHUB_REF" --format='%(contents)' --count=1)"
           annotation_title="$(echo "$annotation" | head -1)"
 
-
           if [[ "$tag" =~ ^(simp-|v)?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[2]}" ]; then
               prerelease=yes
@@ -57,26 +57,26 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
+          echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
-          # * The GitHub Release render the text in this file as markdown
-          # * The file is needed because :set-output only supports single lines
+          # * The GitHub Release renders the text in this file as markdown
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"

--- a/modules/profile/files/_github/workflows/tag_deploy_github-rpms-el7-el8.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_github-rpms-el7-el8.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -71,30 +72,29 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
           echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
           # * The GitHub Release renders the text in this file as markdown
-          # * The file is needed because GITHUB_OUTPUT only supports single lines
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"
 
   build-and-attach-rpms:
     name: Trigger RPM release
@@ -109,16 +109,11 @@ jobs:
           - centos7
           - centos8
     steps:
-      - name: Get tag & annotation info (${{github.ref}})
-        id: tag-check
-        run: |
-          tag="${GITHUB_REF/refs\/tags\//}"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Trigger RPM release workflow (${{ matrix.os }})
         uses: actions/github-script@v6
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
+          TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |

--- a/modules/profile/files/_github/workflows/tag_deploy_github-rpms.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_github-rpms.yml
@@ -38,7 +38,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   create-github-release:
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -74,30 +75,29 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
           echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
           # * The GitHub Release renders the text in this file as markdown
-          # * The file is needed because GITHUB_OUTPUT only supports single lines
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"
 
   build-and-attach-rpms:
     name: Trigger RPM release
@@ -112,16 +112,11 @@ jobs:
           - centos7
           - centos8
     steps:
-      - name: Get tag & annotation info (${{github.ref}})
-        id: tag-check
-        run: |
-          tag="${GITHUB_REF/refs\/tags\//}"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Trigger RPM release workflow (${{ matrix.os }})
         uses: actions/github-script@v6
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
+          TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem.yml
@@ -48,7 +48,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:
@@ -113,6 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -128,7 +129,6 @@ jobs:
           annotation="$(git for-each-ref "$GITHUB_REF" --format='%(contents)' --count=1)"
           annotation_title="$(echo "$annotation" | head -1)"
 
-
           if [[ "$tag" =~ ^(simp-|v)?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[2]}" ]; then
               prerelease=yes
@@ -141,30 +141,27 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
-
+          echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
-          # * The GitHub Release render the text in this file as markdown
-          # * The file is needed because :set-output only supports single lines
+          # * The GitHub Release renders the text in this file as markdown
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
 
   deploy-rubygem:
     name: Deploy RubyGem Release

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-only.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-only.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -116,7 +117,6 @@ jobs:
           annotation="$(git for-each-ref "$GITHUB_REF" --format='%(contents)' --count=1)"
           annotation_title="$(echo "$annotation" | head -1)"
 
-
           if [[ "$tag" =~ ^(simp-|v)?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre|post)?([0-9]+)?)?$ ]]; then
             if [ -n "${BASH_REMATCH[2]}" ]; then
               prerelease=yes
@@ -129,26 +129,26 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
+          echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
-          # * The GitHub Release render the text in this file as markdown
-          # * The file is needed because :set-output only supports single lines
+          # * The GitHub Release renders the text in this file as markdown
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-rpms.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-rpms.yml
@@ -49,7 +49,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:
@@ -114,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -141,30 +142,29 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
           echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
           # * The GitHub Release renders the text in this file as markdown
-          # * The file is needed because GITHUB_OUTPUT only supports single lines
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"
 
   build-and-attach-rpms:
     name: Trigger RPM release
@@ -179,16 +179,11 @@ jobs:
           - centos7
           - centos8
     steps:
-      - name: Get tag & annotation info (${{github.ref}})
-        id: tag-check
-        run: |
-          tag="${GITHUB_REF/refs\/tags\//}"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Trigger RPM release workflow (${{ matrix.os }})
         uses: actions/github-script@v6
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
+          TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   releng-checks:
@@ -55,7 +55,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
+      tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,30 +100,29 @@ jobs:
 
           echo "tag=$tag" | tee -a "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" | tee -a "$GITHUB_OUTPUT"
-          echo "annotation_title=$annotation_title" | tee -a "$GITHUB_OUTPUT"
           echo "TARGET_TAG=$tag" | tee -a "$GITHUB_ENV"
 
           # Prepare annotation body as a file for the next step
           #
           # * The GitHub Release renders the text in this file as markdown
-          # * The file is needed because GITHUB_OUTPUT only supports single lines
           # * The `perl -pe` removes RPM-style date headers from the CHANGELOG,
           #   because they don't render well as markdown on the Release page
-          #
+          echo "RELEASE_MESSAGE<<EOF$$" >> "$GITHUB_ENV"
+          printf '%s\n\n' "$annotation_title" >> "$GITHUB_ENV"
           echo "$annotation" |  tail -n +2 | \
-            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' > /tmp/annotation.body
+            perl -pe 'BEGIN{undef $/;} s/\n\* (Mon|Tue|Wed|Thu|Fri|Sat|Sun) .*?\n//smg;' >> "$GITHUB_ENV"
+          echo "EOF$$" >> "$GITHUB_ENV"
 
       - name: Create Release
-        uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.tag-check.outputs.annotation_title }}
-          body_path: /tmp/annotation.body
-          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
-          draft: false
+        run: |
+          echo "${RELEASE_MESSAGE}" > /tmp/.commit-msg.txt
+          args=(--file /tmp/.commit-msg.txt)
+          [[ ${{ steps.tag-check.outputs.prerelease }} == yes ]] && args+=(--prerelease)
+
+          hub release create ${args[@]} "$TARGET_TAG"
 
   build-and-attach-rpms:
     name: Trigger RPM release
@@ -137,16 +137,11 @@ jobs:
           - centos7
           - centos8
     steps:
-      - name: Get tag & annotation info (${{github.ref}})
-        id: tag-check
-        run: |
-          tag="${GITHUB_REF/refs\/tags\//}"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Trigger RPM release workflow (${{ matrix.os }})
         uses: actions/github-script@v6
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          TARGET_TAG: ${{ steps.tag-check.outputs.tag }}
+          TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
         with:
           github-token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE }}
           script: |
@@ -184,7 +179,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Build Puppet module (PDK)
         run: bundle exec pdk build --force


### PR DESCRIPTION
This patch modernizes GHA workflows to avoid deprecations:

* Replace deprecated create-release@v1
  * Tested pupmod workflow, updated the rest based on that
* Convert the remaining `::set-output` GHA workflows

Fixes #8 
Closes #9