### PR TITLE
Stop generating Compliance Engine wiring in pupmod templates

### DIFF
--- a/dist/puppetsync/functions/setup_repos_facts.pp
+++ b/dist/puppetsync/functions/setup_repos_facts.pp
@@ -45,17 +45,6 @@ function puppetsync::setup_repos_facts(
     }
     $target.add_facts({ 'module_fixtures' => $module_fixtures })
 
-    if (
-      file::exists("${target.vars['repo_path']}/.fixtures.yml")
-      and ['repositories', 'forge_modules', 'symlinks'].any |$key| {
-        $module_fixtures.dig('fixtures', $key, 'compliance_markup')
-      }
-    ) {
-      $target.add_facts({ 'sce_enabled' => true })
-    } else {
-      $target.add_facts({ 'sce_enabled' => false })
-    }
-
     # pupmod_skeleton
     # ------------------------------------------------------------------------
     $skeleton_metadata_json = "${target.vars['repo_path']}/skeleton/metadata.json.erb"

--- a/modules/profile/templates/pupmod/spec/spec_helper.rb.epp
+++ b/modules/profile/templates/pupmod/spec/spec_helper.rb.epp
@@ -32,12 +32,6 @@ default_hiera_config = <<~HIERA_CONFIG
 ---
 version: 5
 hierarchy:
-<% if $facts['sce_enabled'] { -%>
-  - name: SIMP Compliance Engine
-    lookup_key: compliance_markup::enforcement
-    options:
-      enabled_sce_versions: [2]
-<% } -%>
   - name: Custom Test Hiera
     path: "%{custom_hiera}.yaml"
   - name: "%{module_name}"


### PR DESCRIPTION
The Compliance Engine data carried in SIMP modules is no longer maintained, and the `compliance_markup` fixture entry is being removed across pupmod-simp-* repos. With no consumers left, drop the `sce_enabled` fact computation in setup_repos_facts.pp and the conditional SIMP Compliance Engine hierarchy block in the spec_helper.rb.epp template so future syncs don't reintroduce the wiring.