### PR TITLE
Update pupmod baseline to the OpenVox 9 / Ruby 4.0 preview state

### DIFF
--- a/modules/profile/files/_github/workflows/add_new_issue_to_triage_project.yml
+++ b/modules/profile/files/_github/workflows/add_new_issue_to_triage_project.yml
@@ -15,7 +15,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/simp/projects/11
           github-token: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/modules/profile/files/_github/workflows/release_rpms.yml
+++ b/modules/profile/files/_github/workflows/release_rpms.yml
@@ -92,7 +92,7 @@ jobs:
       ${{ (github.event.inputs.target_repo != null && format('{0}/{1}', github.repository_owner, github.event.inputs.target_repo)) || github.repository }}
       ${{ github.event.inputs.release_tag }}
       (build os: ${{ github.event.inputs.build_container_os }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Validate inputs"
         id: validate-inputs
@@ -126,7 +126,7 @@ jobs:
         env:
           AUTOCREATE_RELEASE: ${{ github.event.inputs.autocreate_release }}
           PREBUILD_TAG: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           github-token: ${{ github.event.inputs.target_repo_token || secrets.GITHUB_TOKEN }}
           script: |
@@ -194,7 +194,7 @@ jobs:
             )
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.RELEASE_TAG }}
@@ -259,7 +259,7 @@ jobs:
 
       - name: "Wipe all previous assets from GitHub Release (when clean == 'yes')"
         if: ${{ github.event.inputs.clean == 'yes' && github.event.inputs.dry_run != 'yes' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         env:
           release_id:  ${{ steps.release-api.outputs.id }}
         with:
@@ -278,7 +278,7 @@ jobs:
 
       - name: "Upload RPM file(s) to GitHub Release (dry_run != 'yes')"
         if: ${{ github.event.inputs.dry_run != 'yes' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         env:
           rpm_file_paths: ${{ steps.build-and-sign-rpm.outputs.rpm_file_paths }}
           rpm_gpg_file: ${{ steps.build-and-sign-rpm.outputs.rpm_gpg_file }}

--- a/modules/profile/files/_github/workflows/tag_deploy_github-rpms.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_github-rpms.yml
@@ -38,7 +38,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   create-github-release:

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem.yml
@@ -48,7 +48,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-only.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-only.yml
@@ -35,7 +35,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:

--- a/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-rpms.yml
+++ b/modules/profile/files/_github/workflows/tag_deploy_rubygem__github-rpms.yml
@@ -49,7 +49,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:

--- a/modules/profile/files/pupmod/Gemfile
+++ b/modules/profile/files/pupmod/Gemfile
@@ -6,26 +6,32 @@
 # ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS', 'https://rubygems.org').split(%r{[, ]+})
 
-ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
-
 gem_sources.each { |gem_source| source gem_source }
 
-group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
-  major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
-  gem 'hiera-puppet-helper'
+group :syntax do
   gem 'metadata-json-lint'
-  gem 'pathspec', '~> 2.0' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
-  gem 'puppetlabs_spec_helper'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'puppet-strings'
+  # rubocop, rubocop-rake, and rubocop-rspec are pulled in and version-pinned by
+  # voxpupuli-test (via simp-rake-helpers); pinning them here conflicts with its
+  # constraints. rubocop-performance is not a voxpupuli-test dependency, so it
+  # stays explicit.
+  gem 'rubocop-performance', '~> 1.26.0'
+end
+
+group :test do
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
+  gem 'hiera-puppet-helper'
+  gem 'openvox', openvox_version
+  gem 'openvox-strings'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.21.0', '< 6'])
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 3.7')
+  # renovate: datasource=rubygems versioning=ruby
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
+  # renovate: datasource=rubygems versioning=ruby
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
+  gem 'syslog', require: false
 end
 
 group :development do
@@ -38,7 +44,8 @@ group :system_tests do
   gem 'bcrypt_pbkdf'
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.32.1', '< 2'])
+  # renovate: datasource=rubygems versioning=ruby
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 3.1')
 end
 
 # Evaluate extra gemfiles if they exist

--- a/modules/profile/files/pupmod/_github/workflows/pr_tests.simp-simp.yml
+++ b/modules/profile/files/pupmod/_github/workflows/pr_tests.simp-simp.yml
@@ -8,37 +8,24 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
-
-env:
-  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
     name: 'Puppet Syntax'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -46,26 +33,25 @@ jobs:
     name: 'Puppet Style'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
 
   ruby-style:
-    if: false # TODO Modules will need: rubocop in Gemfile, .rubocop.yml
-    name: 'Ruby Style (experimental)'
+    name: 'Ruby Style'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -75,11 +61,11 @@ jobs:
     name: 'File checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: 'Install Ruby 2.7'
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -88,11 +74,11 @@ jobs:
     name: 'RELENG checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -100,7 +86,7 @@ jobs:
           bundle exec rake pkg:compare_latest_tag[,true]
           bundle exec rake pkg:create_tag_changelog
       - name: 'Test-build the Puppet module'
-        run: 'bundle exec pdk build --force'
+        run: 'bundle exec rake pupmod:build'
 
   spec-tests:
     name: 'Spec (${{matrix.test_suite.label}}, ${{matrix.puppet.label}})'
@@ -109,13 +95,19 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
+            experimental: false
+          - label: 'OpenVox 8.x (Ruby 3.4)'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.4'
+            experimental: false
+          # OpenVox 9 is unreleased; preview the future Ruby 4.0 / OpenVox 9
+          # combo by running the OpenVox 8 gem on Ruby 4.0.
+          - label: 'OpenVox 9.x preview (Ruby 4.0, OpenVox 8 gem)'
+            puppet_version: '~> 8.0'
+            ruby_version: '4.0'
             experimental: false
         test_suite:
           - label: classes 01
@@ -132,13 +124,11 @@ jobs:
             run: bundle exec rspec spec/functions
           - label: aliases
             run: bundle exec rspec spec/type_aliases
-          - label: unit
-            run: bundle exec rspec spec/unit
       fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
@@ -149,12 +139,38 @@ jobs:
       - run: ${{matrix.test_suite.run}}
         continue-on-error: ${{matrix.puppet.experimental}}
 
-#  dump_contexts:
-#    name: 'Examine Context contents'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Dump contexts
-#        env:
-#          GITHUB_CONTEXT: ${{ toJson(github) }}
-#        run: echo "$GITHUB_CONTEXT"
-#
+  acceptance:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - almalinux8
+          - almalinux9
+          - almalinux10
+        suite:
+          - default
+          - base_apps
+      fail-fast: false
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v7
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+      - name: bundle install
+        run: |
+          bundle install
+      - name: Setup libvirt for Vagrant
+        run: |
+          sudo add-apt-repository ppa:evgeni/vagrant
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
+      - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'vagrant_libvirt'
+          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
+        run: |
+          bundle exec rake beaker:suites[${{ matrix.suite}},${{ matrix.node }}]

--- a/modules/profile/files/pupmod/_github/workflows/pr_tests.yml
+++ b/modules/profile/files/pupmod/_github/workflows/pr_tests.yml
@@ -8,37 +8,24 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
-
-env:
-  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
     name: 'Puppet Syntax'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -46,26 +33,25 @@ jobs:
     name: 'Puppet Style'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
 
   ruby-style:
-    if: false # TODO Modules will need: rubocop in Gemfile, .rubocop.yml
-    name: 'Ruby Style (experimental)'
+    name: 'Ruby Style'
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v5
-      - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
+      - uses: actions/checkout@v7
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -75,11 +61,11 @@ jobs:
     name: 'File checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: 'Install Ruby 2.7'
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -88,11 +74,11 @@ jobs:
     name: 'RELENG checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -100,7 +86,7 @@ jobs:
           bundle exec rake pkg:compare_latest_tag[,true]
           bundle exec rake pkg:create_tag_changelog
       - name: 'Test-build the Puppet module'
-        run: 'bundle exec pdk build --force'
+        run: 'bundle exec rake pupmod:build'
 
   spec-tests:
     name: 'Puppet Spec'
@@ -109,34 +95,62 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
+            experimental: false
+          - label: 'OpenVox 8.x (Ruby 3.4)'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.4'
+            experimental: false
+          # OpenVox 9 is unreleased; preview the future Ruby 4.0 / OpenVox 9
+          # combo by running the OpenVox 8 gem on Ruby 4.0.
+          - label: 'OpenVox 9.x preview (Ruby 4.0, OpenVox 8 gem)'
+            puppet_version: '~> 8.0'
+            ruby_version: '4.0'
             experimental: false
       fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
-#  dump_contexts:
-#    name: 'Examine Context contents'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Dump contexts
-#        env:
-#          GITHUB_CONTEXT: ${{ toJson(github) }}
-#        run: echo "$GITHUB_CONTEXT"
-#
+  acceptance:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - almalinux9
+          - almalinux10
+      fail-fast: false
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v7
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+      - name: bundle install
+        run: |
+          bundle install
+      - name: Setup libvirt for Vagrant
+        run: |
+          sudo add-apt-repository ppa:evgeni/vagrant
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
+      - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'vagrant_libvirt'
+          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
+        run: |
+          bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -184,6 +184,12 @@ jobs:
           bundler-cache: true
       - name: Build Puppet module
         run: bundle exec rake pupmod:build
+      - name: Upload module archive as a workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: puppet-module
+          path: pkg/*.tar.gz
+          if-no-files-found: error
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           file="$(find "$PWD/pkg" -name '*.tar.gz')"

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -49,20 +49,20 @@ jobs:
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
       - run: bundle exec rake pkg:create_tag_changelog
       - run: bundle exec rake metadata_lint
       - name: "Test that Puppet module can build"
-        run: "bundle exec pdk build --force"
+        run: "bundle exec rake pupmod:build"
 
 
   create-github-release:
@@ -75,7 +75,7 @@ jobs:
       tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -139,7 +139,7 @@ jobs:
           - centos8
     steps:
       - name: Trigger RPM release workflow (${{ matrix.os }})
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
@@ -174,16 +174,16 @@ jobs:
       FORGE_API_URL: https://forgeapi.puppet.com/v3/releases
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.4.9
           bundler-cache: true
-      - name: Build Puppet module (PDK)
-        run: bundle exec pdk build --force
+      - name: Build Puppet module
+        run: bundle exec rake pupmod:build
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           curl -X POST --silent --show-error --fail \

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -186,8 +186,22 @@ jobs:
         run: bundle exec rake pupmod:build
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
-          curl -X POST --silent --show-error --fail \
+          file="$(find "$PWD/pkg" -name '*.tar.gz')"
+          echo "Uploading: ${file}"
+          response="$(mktemp)"
+          http_code="$(curl -X POST --silent --show-error \
             --user-agent "$FORGE_USER_AGENT" \
             --header "Authorization: Bearer ${PUPPETFORGE_API_TOKEN}" \
-            --form "file=@$(find $PWD/pkg -name ''*.tar.gz'')" \
-            "$FORGE_API_URL"
+            --form "file=@${file}" \
+            --write-out '%{http_code}' \
+            --output "$response" \
+            "$FORGE_API_URL")"
+          echo "Forge API response (HTTP ${http_code}):"
+          cat "$response"; echo
+          case "$http_code" in
+            2*) ;;
+            *)
+              echo "::error ::Puppet Forge upload failed with HTTP ${http_code} (see response above)"
+              exit 1
+              ;;
+          esac

--- a/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
+++ b/modules/profile/files/pupmod/_github/workflows/tag_deploy.yml
@@ -190,6 +190,10 @@ jobs:
           name: puppet-module
           path: pkg/*.tar.gz
           if-no-files-found: error
+      - name: Attach module archive to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" pkg/*.tar.gz --clobber
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           file="$(find "$PWD/pkg" -name '*.tar.gz')"

--- a/modules/profile/templates/pupmod/spec/spec_helper.rb.epp
+++ b/modules/profile/templates/pupmod/spec/spec_helper.rb.epp
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # ------------------------------------------------------------------------------
 #         NOTICE: **This file is maintained with puppetsync**
@@ -7,7 +8,7 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts
@@ -29,18 +30,18 @@ if ENV['PUPPET_DEBUG']
 end
 
 default_hiera_config = <<~HIERA_CONFIG
----
-version: 5
-hierarchy:
-  - name: Custom Test Hiera
-    path: "%{custom_hiera}.yaml"
-  - name: "%{module_name}"
-    path: "%{module_name}.yaml"
-  - name: Common
-    path: default.yaml
-defaults:
-  data_hash: yaml_data
-  datadir: "stub"
+  ---
+  version: 5
+  hierarchy:
+    - name: Custom Test Hiera
+      path: "%{custom_hiera}.yaml"
+    - name: "%{module_name}"
+      path: "%{module_name}.yaml"
+    - name: Common
+      path: default.yaml
+  defaults:
+    data_hash: yaml_data
+    datadir: "stub"
 HIERA_CONFIG
 
 # This can be used from inside your spec tests to set the testable environment.
@@ -91,16 +92,17 @@ RSpec.configure do |c|
   # If nothing else...
   c.default_facts = {
     production: {
-      #:fqdn           => 'production.rspec.test.localdomain',
+      # :fqdn           => 'production.rspec.test.localdomain',
       path: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      concat_basedir: '/tmp'
-    }
+      concat_basedir: '/tmp',
+    },
   }
 
   c.mock_framework = :rspec
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 
@@ -151,9 +153,9 @@ RSpec.configure do |c|
 
     # sanitize hieradata
     if defined?(hieradata)
-      set_hieradata(hieradata.gsub(':', '_'))
+      set_hieradata(hieradata.tr(':', '_'))
     elsif defined?(class_name)
-      set_hieradata(class_name.gsub(':', '_'))
+      set_hieradata(class_name.tr(':', '_'))
     end
   end
 
@@ -165,9 +167,7 @@ RSpec.configure do |c|
 end
 
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
-  begin
-    Pathname.new(dir).realpath
-  rescue StandardError
-    raise "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
-  end
+  Pathname.new(dir).realpath
+rescue StandardError
+  raise "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
 end


### PR DESCRIPTION
Updates the pupmod baseline assets to match what is actually deployed on the fleet-wide `openvox9-ruby4-preview` branches (71 modules, all green in CI). **Do not run puppetsync from this yet** — this PR only reconciles the templates with reality so the next sync starts from a truthful baseline.

Where deployed files varied, the template takes the **fleet-majority variant** (counts below are out of 71 modules).

### Changes

| Asset | Update | Consensus |
|---|---|---|
| `pupmod/Gemfile` | No `puppet`/`pdk`/`puppetlabs_spec_helper` gems; `openvox`, `openvox-strings`, voxpupuli-test stack via `simp-rake-helpers ~> 6.0`, `simp-beaker-helpers ~> 3.1`, `simp-rspec-puppet-facts ~> 4.0`; rubocop pins removed (managed by voxpupuli-test) | 26 identical; rest carry local additions |
| `spec_helper.rb.epp` | `require 'voxpupuli/test/spec_helper'`; refreshed body (squiggly heredoc, trailing commas); simpkv conditional kept | 19 + near-identical variants |
| `pr_tests.yml` | checkout@v7, lint jobs on Ruby 3.2.11, Ruby Style enabled (still `continue-on-error`), RELENG/file-checks on 3.4.9, `rake pupmod:build`, 3-row spec matrix (OpenVox 8 × Ruby 3.2/3.4 + **OpenVox 9 preview × Ruby 4.0**, all blocking), `parallel_spec`, majority acceptance job | see notes |
| `pr_tests.simp-simp.yml` | Refreshed from simp-simp's deployed workflow (split spec suites, multi-suite acceptance) | exact |
| `tag_deploy.yml` | Ruby 3.4.9, `rake pupmod:build` (label "(PDK)" dropped) | 46 |
| `release_rpms.yml` | ubuntu-24.04, github-script@v9, checkout@v7 | 65 |
| `add_new_issue_to_triage_project.yml` | add-to-project@v2 | 62 |

Unchanged because the fleet still matches: `validate_tokens.yml`, `_pdkignore`, `_rspec`, `_gitignore`, `_gitattributes`, `_puppet-lint.rc`.

### Known divergences a future sync must handle (NOT resolved here)

1. **Acceptance job varies by module** — 37 vagrant_libvirt (kernel-level tests) / 25 docker+podman / 9 none, with differing node lists. The baseline carries the majority variant (vagrant, almalinux 9+10, 23 modules). Everything else needs per-repo `pr_tests.<repo_name>.yml` overrides (mechanism already exists in `profile::github_actions`) or a data-driven EPP before the next sync — otherwise the sync will clobber the docker matrices.
2. **Gemfile local additions** — e.g. `gem 'observer'` (27 modules, needed by compliance-profile specs on Ruby 3.4+), `beaker_puppet_helpers` (auditd). A static-file sync would remove them.
3. **`.puppet-lint.rc`** — 17 modules added `--no-strict_indent-check` to work around the broken strict_indent v5.0.0 plugin (crashes puppet-lint). Template left at the majority (no workaround).
4. **Ruby Style `continue-on-error: true`** — kept to match reality; removing it is #41 (rubocop is now clean fleet-wide, so it could be enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCnDsYaJDLiP8z8tafz9Tp
