### PR TITLE
Add create_release_tag.yml workflow for pupmod repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- New GHA workflow for pupmod repos, `create_release_tag.yml`
-  - Manually-dispatched (`workflow_dispatch`) release tagging
-  - Reads the version from `metadata.json`, validates it
-    (`pkg:check_version`, `pkg:compare_latest_tag`, `metadata_lint`),
-    generates the tag annotation from the CHANGELOG
-    (`pkg:create_tag_changelog`), and pushes the annotated tag
-  - The pushed tag triggers `tag_deploy.yml` (requires the
-    `SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE` PAT secret to push)
-  - Supports a `dry_run` input that validates and prints the tag
-    annotation without pushing
 - New GHA workflow, `add_new_issue_to_triage_project.yml`
 - New task, `generate_reference_md`
   - Generates up-to-date `REFERENCE.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- New GHA workflow for pupmod repos, `create_release_tag.yml`
+  - Manually-dispatched (`workflow_dispatch`) release tagging
+  - Reads the version from `metadata.json`, validates it
+    (`pkg:check_version`, `pkg:compare_latest_tag`, `metadata_lint`),
+    generates the tag annotation from the CHANGELOG
+    (`pkg:create_tag_changelog`), and pushes the annotated tag
+  - The pushed tag triggers `tag_deploy.yml` (requires the
+    `SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE` PAT secret to push)
+  - Supports a `dry_run` input that validates and prints the tag
+    annotation without pushing
 - New GHA workflow, `add_new_issue_to_triage_project.yml`
 - New task, `generate_reference_md`
   - Generates up-to-date `REFERENCE.md`

--- a/data/project_types/pupmod.yaml
+++ b/data/project_types/pupmod.yaml
@@ -14,6 +14,7 @@ profile::github_actions::absent_action_files:
 
 profile::github_actions::present_action_files:
   - pr_tests.yml         # PR-triggered Pupmod checks + test matrix
+  - create_release_tag.yml  # Manually create + push a release tag
   - tag_deploy.yml       # Release on tag, deploy pupmod to forge, RPMs to GH
   - release_rpms.yml     # Build, sign, upload RPMs to a release from any repo
   - validate_tokens.yml  # Diagnostic workflow to check API tokens work

--- a/modules/profile/files/pupmod/_github/workflows/create_release_tag.yml
+++ b/modules/profile/files/pupmod/_github/workflows/create_release_tag.yml
@@ -1,0 +1,115 @@
+# Manual action to create + push a release tag from metadata.json & CHANGELOG
+# ------------------------------------------------------------------------------
+#
+#             NOTICE: **This file is maintained with puppetsync**
+#
+# This file is updated automatically as part of a puppet module baseline.
+#
+# The next baseline sync will overwrite any local changes to this file!
+#
+# ==============================================================================
+# This pipeline uses the following GitHub Action Secrets:
+#
+#   GitHub Secret variable               Notes
+#   -------------------------------      ---------------------------------------
+#   SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE   Used to push the release tag. A PAT is
+#                                        required in order for the pushed tag to
+#                                        trigger the `tag_deploy.yml` workflow
+#                                        (events created with the workflow's own
+#                                        GITHUB_TOKEN do not trigger other
+#                                        workflows). Falls back to GITHUB_TOKEN,
+#                                        which still creates the tag but will
+#                                        NOT trigger the release workflow.
+#
+# ------------------------------------------------------------------------------
+#
+# * This is a workflow_dispatch action, which can be triggered manually or from
+#   other workflows/API
+#
+# * It must be dispatched from the repository's default branch
+#
+# * The tag version is read from `metadata.json` and the tag's annotation is
+#   generated from the CHANGELOG (`rake pkg:create_tag_changelog`)
+#
+# * Pushing the tag triggers the `tag_deploy.yml` release workflow
+#
+---
+name: 'RELENG: Create release tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (validate + report the tag annotation, don't push)"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  PUPPET_VERSION: '~> 8'
+
+jobs:
+  create-release-tag:
+    name: 'Create release tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: "Assert '${{ github.ref }}' is the default branch"
+        env:
+          DEFAULT_BRANCH_REF: 'refs/heads/${{ github.event.repository.default_branch }}'
+        run: |
+          [[ "$GITHUB_REF" == "$DEFAULT_BRANCH_REF" ]] || \
+            { echo "::error ::Dispatched ref '${GITHUB_REF}' is not the default branch ('${DEFAULT_BRANCH_REF}')"; exit 1; }
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0  # tag history is needed for `rake pkg:compare_latest_tag`
+          token: ${{ secrets.SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE || github.token }}
+
+      - name: Read + validate version from metadata.json
+        id: version
+        run: |
+          version="$(jq -r .version metadata.json)"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?$ ]]; then
+            echo "::error ::metadata.json version '${version}' is not SemVer (X.Y.Z or X.Y.Z-<prerelease>)"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+            echo "::error ::Tag '${version}' already exists"
+            exit 1
+          fi
+          echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+
+      - name: RELENG sanity checks
+        run: |
+          bundle exec rake pkg:check_version
+          bundle exec rake pkg:compare_latest_tag
+          bundle exec rake metadata_lint
+
+      - name: Generate tag annotation from CHANGELOG
+        env:
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          bundle exec rake pkg:create_tag_changelog > "/tmp/tag_annotation_${TARGET_VERSION}.txt"
+          echo '::group::Tag annotation'
+          cat "/tmp/tag_annotation_${TARGET_VERSION}.txt"
+          echo '::endgroup::'
+
+      - name: Create + push annotated tag (skipped when dry_run)
+        if: ${{ !inputs.dry_run }}
+        env:
+          TARGET_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a "$TARGET_VERSION" -F "/tmp/tag_annotation_${TARGET_VERSION}.txt"
+          git push origin "refs/tags/${TARGET_VERSION}"
+          echo "Pushed tag \`${TARGET_VERSION}\` (this triggers the \`tag_deploy.yml\` release workflow)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### What this does

Adds a new puppetsync-managed GitHub Actions workflow, `create_release_tag.yml`, for all pupmod repos, replacing the local shell script currently used to tag module releases.

It is a `workflow_dispatch` action that:

- Must be dispatched from the repository's default branch (asserted)
- Reads the release version from `metadata.json` and validates it: SemVer format, tag doesn't already exist, `rake pkg:check_version`, `rake pkg:compare_latest_tag`, and `rake metadata_lint` — all *before* tagging (today these only run in `tag_deploy.yml`, after the tag is already pushed)
- Generates the tag annotation from the CHANGELOG via `rake pkg:create_tag_changelog` (same as the local script)
- Creates the annotated tag and pushes it, triggering the existing `tag_deploy.yml` release pipeline
- Supports a `dry_run` input that validates everything and prints the would-be annotation without pushing

### Notes

- **Token**: the checkout/push uses `SIMP_AUTO_GITHUB_TOKEN__REPO_SCOPE` (the same org PAT `tag_deploy.yml` already uses to dispatch `release_rpms.yml`), because tags pushed with the default `GITHUB_TOKEN` do not trigger other workflows. It falls back to `GITHUB_TOKEN` (documented in the header), which still creates the tag but won't fire `tag_deploy.yml`.
- Verified there are no rulesets or tag protections on the pupmod repos and the org's default workflow permissions are `write`, so the push itself is unobstructed; the job also declares `permissions: contents: write` explicitly.
- Conventions match the currently-deployed workflows (`actions/checkout@v7`, `ruby/setup-ruby@v1` with Ruby 3.4.9, `PUPPET_VERSION: '~> 8'`) rather than the older pinning still present in some templates here, so Renovate can manage the versions per-repo after sync.
- Improvements over the local script: no root-owned `vendor/`+`Gemfile.lock` litter in the working tree, an enforced local-matches-origin default branch (it tags what's actually on GitHub), pre-tag RELENG validation, and a dry-run mode replacing the 5-second Ctrl-C window.
- pupmod project type only; the rubygem repos use different tooling and could get an equivalent later if this works out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)