### PR TITLE
Pull RPM build containers from ghcr.io/simp/simp-<os>-build (fixes fleet-wide RPM build failures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `release_rpms.yml` now pulls build containers from `ghcr.io/simp/simp-<os>-build`
+  instead of the retired `docker.io/simpproject/simp_build_<os>` images
+  - New `build_container_tag` input (default `latest`) to pin a dated container tag
+  - `build_container_os` default changed from `centos8` to `el8`
 - Update GHA ruby tag deploy workflows to use `$GITHUB_OUTPUT`, Ruby 2.7
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- `release_rpms.yml` now pulls build containers from `ghcr.io/simp/simp-<os>-build`
-  instead of the retired `docker.io/simpproject/simp_build_<os>` images
-  - New `build_container_tag` input (default `latest`) to pin a dated container tag
-  - `build_container_os` default changed from `centos8` to `el8`
 - Update GHA ruby tag deploy workflows to use `$GITHUB_OUTPUT`, Ruby 2.7
 
 ### Fixed

--- a/modules/profile/files/_github/workflows/release_rpms.yml
+++ b/modules/profile/files/_github/workflows/release_rpms.yml
@@ -54,7 +54,11 @@ on:
       build_container_os:
         description: "Build container OS"
         required: true
-        default: 'centos8'
+        default: 'el8'
+      build_container_tag:
+        description: "Build container tag"
+        required: true
+        default: 'latest'
       target_repo:
         description: "Target repo (instead of this one)"
         required: false
@@ -253,7 +257,7 @@ jobs:
           gpg_signing_key_id: ${{ secrets.SIMP_DEV_GPG_SIGNING_KEY_ID }}
           gpg_signing_key_passphrase: ${{ secrets.SIMP_DEV_GPG_SIGNING_KEY_PASSPHRASE }}
           simp_core_ref_for_building_rpms: ${{ secrets.SIMP_CORE_REF_FOR_BUILDING_RPMS }}
-          simp_builder_docker_image: 'docker.io/simpproject/simp_build_${{ github.event.inputs.build_container_os }}:latest'
+          simp_builder_docker_image: 'ghcr.io/simp/simp-${{ github.event.inputs.build_container_os }}-build:${{ github.event.inputs.build_container_tag }}'
           path_to_build: "${{ (github.event.inputs.path_to_build != null && format('{0}/{1}', github.workspace, github.event.inputs.path_to_build)) || github.workspace }}"
           verbose: 'no'  #${{ github.event.inputs.verbose }}
 


### PR DESCRIPTION
## Problem

`release_rpms.yml` resolves its builder image as:

```yaml
simp_builder_docker_image: 'docker.io/simpproject/simp_build_${{ github.event.inputs.build_container_os }}:latest'
```

**Docker Hub's `simpproject/` namespace has no EL8/9/10 build images.** The only relevant ones are:

| Image | Last pushed |
|---|---|
| `simpproject/simp_build_centos7` | 2024-08-09 |
| `simpproject/simp_build_centos8` | 2023-06-26 |

(plus older `centos6` and `*_ruby3_1` variants). So no value of `build_container_os` can select a current container — `simpproject/simp_build_el8` does not exist.

Building against those years-old images fails with:

```
NameError: uninitialized constant JSON::Fragment
```

`JSON::Fragment` was added in the `json` gem 2.9; the stale images ship older. As of 2026-07-28 this is failing in **70 of 71** non-archived repos that have run the workflow, spanning 2026-06-09 → 2026-07-24 — i.e. through the entire 7.0.0/8.0.0 release wave.

## Fix

Point at the current containers, which are public and rebuilt weekly:

| Image | Tags |
|---|---|
| `ghcr.io/simp/simp-el8-build` | `latest`, `20260428` … `20260720` |
| `ghcr.io/simp/simp-el9-build` | `latest`, `20260428` … `20260720` |
| `ghcr.io/simp/simp-el10-build` | `latest`, `20260618` … `20260727` |

Three changes:

1. `simp_builder_docker_image` → `ghcr.io/simp/simp-${os}-build:${tag}` — note both the **registry host** and the **image-name shape** differ from the old form.
2. New `build_container_tag` input (default `latest`) so a dated tag can be pinned for reproducible rebuilds.
3. `build_container_os` default `centos8` → `el8` (lowest currently supported EL, so the widest RPM compatibility).

## This is already proven in production

`pupmod-simp-mockup` has carried exactly this configuration for a while and is the only repo with it. **The single green `release_rpms.yml` run anywhere in the org came from it:** `simp/pupmod-simp-simplib 5.0.3 (build os: el10)`, dispatched through mockup's workflow via `target_repo` on 2026-06-22 — signing and release-asset attachment included. This PR ports that working configuration into the baseline so the other 78 repos get it.

Diffed against `pupmod-simp-mockup`'s copy; this PR is the mockup delta **minus** the runner/action bumps, which #42 already owns (see below).

## Relationship to #42

#42 also touches this file, but only bumps `runs-on: ubuntu-20.04` → `24.04`, `actions/github-script@v6` → `@v9`, and `actions/checkout@v5` → `@v7`. It does **not** touch the image reference, the input defaults, or add `build_container_tag`. The two changes are complementary and deliberately kept separate.

⚠️ **Merge-order note:** my image-line hunk ends around template line 259 and one of #42's `github-script@v9` hunks starts around line 259, so whichever merges second may need a trivial context resolution. There is no semantic conflict — keep both sides (the `ghcr.io` image line *and* the `@v9` bump).

## Deliberately not included

- **`verbose` input.** mockup un-comments the `verbose` workflow input, but its build step still hardcodes `verbose: 'no'  #${{ github.event.inputs.verbose }}`, so the input would be exposed while doing nothing. Left as-is here rather than shipping a no-op knob fleet-wide — worth either wiring up properly or leaving commented, as a separate decision.
- **The prerelease-tag defect.** `release_rpms.yml:105`'s tag regex captures the prerelease *counter* as a separate optional group from the prerelease *word* and has no release (`-R`) component, which is consistent with simp-core#864 / simp-doc#461 (`simp-6.6.0-Alpha.el8.noarch.rpm` instead of `simp-6.6.0-Alpha10-1…`). Same file, separate defect — kept out to keep this reviewable.

## Verification suggested before syncing to all 78 repos

A release does **not** have to wait on the sync: because mockup's workflow accepts `target_repo` + `target_repo_token`, RPMs can be built and attached for any repo through mockup today. Recommended order:

1. Dispatch with `dry_run=yes` against one module and confirm the container pulls and the build runs.
2. One real simple module, then one with native/provider bits.
3. Confirm `SIMP_CORE_REF_FOR_BUILDING_RPMS` (reportedly still `6.5.0-1`) is still viable — a real build exercises it immediately.
4. Then sync this template out.
