### PR TITLE
Remove archived pupmod-simp-ntpd from sync repolists

### DIFF
--- a/data/sync/repolists/20230313-add-gcp-to-glci.yaml
+++ b/data/sync/repolists/20230313-add-gcp-to-glci.yaml
@@ -111,9 +111,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/20231005-puppet8.yaml
+++ b/data/sync/repolists/20231005-puppet8.yaml
@@ -100,9 +100,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/20231012-el9.yaml
+++ b/data/sync/repolists/20231012-el9.yaml
@@ -105,10 +105,7 @@ puppetsync::repos_config:
 
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
-
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
+    
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/20231012-el9.yaml
+++ b/data/sync/repolists/20231012-el9.yaml
@@ -105,7 +105,7 @@ puppetsync::repos_config:
 
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
-    
+
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/20240522-remove-glci-actions.yaml
+++ b/data/sync/repolists/20240522-remove-glci-actions.yaml
@@ -74,8 +74,6 @@ puppetsync::repos_config:
     branch: master
   https://github.com/simp/pupmod-simp-network:
     branch: master
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
   https://github.com/simp/pupmod-simp-oath:
     branch: master
   https://github.com/simp/pupmod-simp-oddjob:

--- a/data/sync/repolists/20240612-puppet8-tests.yaml
+++ b/data/sync/repolists/20240612-puppet8-tests.yaml
@@ -70,8 +70,6 @@ puppetsync::repos_config:
     branch: master
   https://github.com/simp/pupmod-simp-network:
     branch: master
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
   https://github.com/simp/pupmod-simp-oath:
     branch: master
   https://github.com/simp/pupmod-simp-oddjob:

--- a/data/sync/repolists/20240905-iptables-7.yaml
+++ b/data/sync/repolists/20240905-iptables-7.yaml
@@ -24,8 +24,6 @@ puppetsync::repos_config:
     branch: master
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
   https://github.com/simp/pupmod-simp-pam:
     branch: master
   https://github.com/simp/pupmod-simp-postfix:

--- a/data/sync/repolists/20251009-drop-glci.yaml
+++ b/data/sync/repolists/20251009-drop-glci.yaml
@@ -152,8 +152,6 @@ puppetsync::repos_config:
     branch: master
   https://github.com/simp/pupmod-simp-sssd:
     branch: master
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
   https://github.com/simp/pupmod-simp-clamav:
     branch: master
   https://github.com/simp/pupmod-simp-ssh:

--- a/data/sync/repolists/almalinux_8/pupmods_batch_03.yaml
+++ b/data/sync/repolists/almalinux_8/pupmods_batch_03.yaml
@@ -108,9 +108,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   # https://github.com/simp/pupmod-simp-oath:
   #   branch: master
 

--- a/data/sync/repolists/gcp__batch_03.yaml
+++ b/data/sync/repolists/gcp__batch_03.yaml
@@ -36,7 +36,5 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
 
 

--- a/data/sync/repolists/p+r_test.yaml
+++ b/data/sync/repolists/p+r_test.yaml
@@ -7,9 +7,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-rsyslog:
     branch: master
 

--- a/data/sync/repolists/pupmods.yaml
+++ b/data/sync/repolists/pupmods.yaml
@@ -100,9 +100,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/pupmods__batch_06.yaml
+++ b/data/sync/repolists/pupmods__batch_06.yaml
@@ -99,9 +99,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 

--- a/data/sync/repolists/pupmods_remaining.yaml
+++ b/data/sync/repolists/pupmods_remaining.yaml
@@ -99,9 +99,6 @@ puppetsync::repos_config:
   https://github.com/simp/pupmod-simp-nfs:
     branch: master
 
-  https://github.com/simp/pupmod-simp-ntpd:
-    branch: master
-
   https://github.com/simp/pupmod-simp-oath:
     branch: master
 


### PR DESCRIPTION
Removes every remaining active `pupmod-simp-ntpd` sync target from `data/sync/repolists/` (13 files) so puppetsync no longer targets the archived repo — the module's entries in the other batch lists were already commented out and are left as-is. The `simp/ntpd` entry in `dist/puppetsync/data/version_requirements.json` is deliberately untouched: that's the metadata.json dependency-version map, not a sync target, and modules may still declare the dependency.

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)