### PR TITLE
Fail fast on unrecordable stage results instead of binding.pry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update GHA ruby tag deploy workflows to use `$GITHUB_OUTPUT`, Ruby 2.7
+- `puppetsync::pipeline_stage` now raises a clear error when a stage block
+  returns something other than Bolt results, instead of dropping into an
+  interactive `binding.pry` debugger that would hang unattended runs (#52)
 
 ### Fixed
 

--- a/dist/puppetsync/lib/puppet/functions/puppetsync/pipeline_stage.rb
+++ b/dist/puppetsync/lib/puppet/functions/puppetsync/pipeline_stage.rb
@@ -1,4 +1,5 @@
-# Parse Puppetfile contents
+# Run a block of plan logic as a named, skippable pipeline stage and record
+# its results on each Target
 Puppet::Functions.create_function(:'puppetsync::pipeline_stage') do
   dispatch :pipeline_stage do
     param 'Boltlib::TargetSpec', :targets
@@ -38,19 +39,12 @@ Puppet::Functions.create_function(:'puppetsync::pipeline_stage') do
       call_function('out::message', "puppetsync::record_stage_results( #{stage_name}, #{results.class})")
       call_function('puppetsync::record_stage_results', stage_name, results)
     else
-      STDERR.puts '############ WARNING: results are NOT a Bolt::Result'
-      Puppet.warning "############ WARNING: results are NOT a Bolt::Result (file:#{__FILE__}, stage: #{stage_name}, class: #{results.class}"
-      if results.kind_of? Array
-        Puppet.warning "############ WARNING: ARRAY.size: #{results.size}"
-        Puppet.warning "############ WARNING: ARRAY.first class: #{results.first.class}"
-      end
-
-
-      begin
-        require 'pry'; binding.pry
-      rescue LoadError => e
-        puts "==============================================================", e.message
-      end
+      details = results.is_a?(Array) ? " of [#{results.map(&:class).uniq.join(', ')}] (size: #{results.size})" : ''
+      raise Puppet::Error,
+            "puppetsync::pipeline_stage('#{stage_name}'): the stage block returned " \
+            "#{results.class}#{details}, but a Bolt::Result, Bolt::ResultSet, or " \
+            'Array of Bolt::Results is required. Unrecordable results would let ' \
+            'failed targets continue through later stages, so this is a fatal error.'
     end
     ok_targets
   end


### PR DESCRIPTION
Closes #52

`puppetsync::pipeline_stage` had a debugging leftover in its results-handling: when a stage block returned something other than a `Bolt::Result`/`Bolt::ResultSet` (or an `Array` of `Result`s), it printed warnings, dropped into an interactive `binding.pry`, and then **continued with the stage's results unrecorded**. That's two problems:

1. An interactive debugger in the critical path hangs any unattended run (CI, scheduled, or just walked-away-from) — a blocker for the continuous-enforcement direction (#56).
2. Unrecorded results corrupt the pipeline's core safety mechanism: the "only run targets that succeeded so far" filter reads `puppetsync_stage_results`, so a stage that fails to record lets failed targets sail into later stages as if they were fine.

This replaces the whole branch with a raised `Puppet::Error` naming the stage, the offending type (with element types and size when it's an Array), and why it's fatal. Also fixes the stale "Parse Puppetfile contents" doc comment on the function (copy-paste leftover).

## Safety check

I audited every `pipeline_stage` call site (`init.pp`, `approve_github_prs.pp`, `merge_github_prs.pp`, `release_pupmod.pp`): each stage block ends in `run_task`/`run_task_with`/`run_command`/`apply` (→ `ResultSet`) or a `.map` producing `Array[Bolt::Result]`, all of which the function already handles. The pry branch is only reachable from a not-yet-written stage returning the wrong thing — exactly the case that should fail loudly at development time.

## Verification

Exercised both paths with a throwaway plan (not committed) against openbolt 5.6.0:

- **Happy path**: a stage returning a real `ResultSet` still records (`recorded: [good_stage]`) and the plan completes.
- **Error path**: a stage returning a `String` fails the plan immediately with:
  > `puppetsync::pipeline_stage('bad_stage'): the stage block returned String, but a Bolt::Result, Bolt::ResultSet, or Array of Bolt::Results is required. Unrecordable results would let failed targets continue through later stages, so this is a fatal error.`
  including the plan file/line of the offending stage.

Also green locally: `rspec` (139 examples, 0 failures), `bolt plan show puppetsync`, and the `list_pipeline_stages` dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
