### PR TITLE
Make puppetsync fully idempotent for repos that need no changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Verify the puppetsync plans load
         run: /opt/puppetlabs/bolt/bin/bolt plan show puppetsync
 
+      - name: Idempotency end-to-end test (local fixture repo)
+        run: ./scripts/ci-e2e-idempotency.sh
+
       - name: List pipeline stages (plan dry run)
         env:
           # The plan requires these to be set, but nothing calls the APIs in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The `puppetsync` plan is now fully idempotent: repos that need no changes
+  pass through cleanly instead of failing at the PR stage (#49)
+  - The `git_commit` task reports `changed: false` when there is nothing to
+    commit (and now propagates real `git` failures instead of swallowing
+    them; amend detection also works for single-line commit messages)
+  - Unchanged repos skip the GitHub fork/push/PR stages
+  - The final summary reports three buckets: ok / unchanged / failed
 - Update GHA ruby tag deploy workflows to use `$GITHUB_OUTPUT`, Ruby 2.7
 - `puppetsync::pipeline_stage` now raises a clear error when a stage block
   returns something other than Bolt results, instead of dropping into an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `checkout_git_feature_branch_in_each_repo` branch-existence detection was
+  broken on systems where `/bin/sh` is not bash (e.g. Ubuntu/dash): the old
+  backticks + `&>` check always reported the branch as existing, so checkout
+  failed on the first run. Found by the new idempotency e2e test in CI.
 - Rubygem GHA workflow bug that prevented tagged releases/pre-releases (x2)
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ It will then execute the following pipeline stages for each repo (in parallel):
 If an individual repo encounters failures during a stage, it will be held back
 while the other repos proceed with their workflows.
 
+Repos that need no changes are safe to sync: they are reported as
+`unchanged` and skip the GitHub fork/push/PR stages.
+
 All failures are summarized after the full plan finishes executing.
 
 #### `puppetsync::approve_github_prs`

--- a/dist/puppetsync/functions/output_pipeline_results.pp
+++ b/dist/puppetsync/functions/output_pipeline_results.pp
@@ -22,6 +22,21 @@ function puppetsync::output_pipeline_results(
 
   out::message("\n${repos.puppetsync::summarize_repos_pipeline_results(true)}\n\n")
 
+  $buckets = $repos.map |$repo| {
+    $all_ok = $repo.vars['puppetsync_stage_results'].all |$k,$v| { $v['ok'] }
+    $all_ok ? {
+      false   => 'failed',
+      default => $repo.vars['puppetsync_unchanged'] ? { true => 'unchanged', default => 'ok' },
+    }
+  }
+  out::message( sprintf(
+    "===== %d ok / %d unchanged / %d failed (%d total)\n",
+    $buckets.filter |$x| { $x == 'ok' }.size,
+    $buckets.filter |$x| { $x == 'unchanged' }.size,
+    $buckets.filter |$x| { $x == 'failed' }.size,
+    $buckets.size,
+  ))
+
   $failures = $repos.map |$k,$x| { $x.vars['puppetsync_stage_results'].filter |$x, $y| { $y['ok'] == false } }
   unless $failures.all |$x| { $x.empty } {
     $f_hashes = $failures.map |$k,$v| {

--- a/dist/puppetsync/functions/summarize_repos_pipeline_results.pp
+++ b/dist/puppetsync/functions/summarize_repos_pipeline_results.pp
@@ -10,14 +10,24 @@ function puppetsync::summarize_repos_pipeline_results(
     rows  => $repos.map |$repo| {
       $all_ok = $repo.vars['puppetsync_stage_results'].all |$k,$v| { $v['ok'] }
       $stage = $repo.vars['puppetsync_stage_results'].keys[-1].lest || {  $repo.vars['puppetsync_stage_results'].count }
+      $status = $all_ok ? {
+        false   => 'failed',
+        default => $repo.vars['puppetsync_unchanged'] ? { true => 'unchanged', default => 'ok' },
+      }
       if $colorize {
-        [
-          $all_ok ? { true => $repo.name, default => format::colorize( $repo.name, 'warning' ) },
-          $all_ok ? { true => format::colorize('ok', 'good'), default => format::colorize('failed','fatal') },
-          $all_ok ? { true =>  $stage, default => format::colorize($stage, 'warning') },
-        ]
+        case $status {
+          'failed': {
+            [ format::colorize( $repo.name, 'warning' ), format::colorize('failed','fatal'), format::colorize($stage, 'warning') ]
+          }
+          'unchanged': {
+            [ $repo.name, 'unchanged', $stage ]
+          }
+          default: {
+            [ $repo.name, format::colorize('ok', 'good'), $stage ]
+          }
+        }
       } else {
-        [ $repo.name, $all_ok ? { true => 'ok', default => 'failed' }, $stage ]
+        [ $repo.name, $status, $stage ]
       }
     }
   })

--- a/dist/puppetsync/lib/puppet/functions/puppetsync/pipeline_stage.rb
+++ b/dist/puppetsync/lib/puppet/functions/puppetsync/pipeline_stage.rb
@@ -26,6 +26,15 @@ Puppet::Functions.create_function(:'puppetsync::pipeline_stage') do
     Puppet.warning("== Preparing stage '#{stage_name}'")
     ok_targets = targets.select { |repo| repo.vars['puppetsync_stage_results'].all? { |k,v| v['ok']}}
 
+    # Skip targets whose repos needed no changes (see the git_commit task),
+    # so no-change repos pass through fork/push/PR stages cleanly
+    if opts['skip_unchanged_targets']
+      unchanged, ok_targets = ok_targets.partition { |t| t.vars['puppetsync_unchanged'] }
+      unless unchanged.empty?
+        call_function('out::message', "===== SKIPPING #{unchanged.size} UNCHANGED TARGET(S) FOR STAGE: #{stage_name}")
+      end
+    end
+
     # Run stage block
     Puppet.warning('filtered ok stages before running')
     results = yield(ok_targets, stage_name)

--- a/dist/puppetsync/plans/init.pp
+++ b/dist/puppetsync/plans/init.pp
@@ -353,7 +353,7 @@ plan puppetsync(
     $opts
   ) |$ok_repos, $stage_name| {
     $commit_message = $puppetsync_config.dig('git','commit_message').lest || {''}
-    run_task_with(
+    $results = run_task_with(
       'puppetsync::git_commit',
       $ok_repos,
       '_catch_errors'  => true,
@@ -363,6 +363,17 @@ plan puppetsync(
         'commit_message' => puppetsync::template_git_commit_message($repo,$puppetsync_config),
       }
     }
+
+    # Flag repos that needed no changes so later stages can skip them
+    # (see 'skip_unchanged_targets' in puppetsync::pipeline_stage)
+    $ok_repos.each |$repo| {
+      $result = $results.filter |$r| { $r.target.name == $repo.name }[0]
+      if $result and $result.ok and $result.value['changed'] == false {
+        $repo.set_var('puppetsync_unchanged', true)
+        out::message( "-- ${repo.name}: no changes to commit; skipping GitHub stages" )
+      }
+    }
+    $results
   }
 
 
@@ -370,7 +381,7 @@ plan puppetsync(
     # --------------------------------------------------------------------------
     'ensure_github_fork',
     # --------------------------------------------------------------------------
-    $opts
+    $opts + { 'skip_unchanged_targets' => true }
   ) |$ok_repos, $stage_name| {
     $results = run_task_with(
       'puppetsync::ensure_github_fork', $ok_repos, '_catch_errors' => true
@@ -396,7 +407,7 @@ plan puppetsync(
     # --------------------------------------------------------------------------
     'ensure_git_remote',
     # --------------------------------------------------------------------------
-    $opts
+    $opts + { 'skip_unchanged_targets' => true }
   ) |$ok_repos, $stage_name| {
     $ok_repos.each |$repo| {$repo.set_var('remote_name', 'user_forked_repo')}
     $results = run_task_with(
@@ -427,7 +438,7 @@ plan puppetsync(
     # --------------------------------------------------------------------------
     'git_push_to_remote',
     # --------------------------------------------------------------------------
-    $opts
+    $opts + { 'skip_unchanged_targets' => true }
   ) |$ok_repos, $stage_name| {
     $ok_repos.map |$repo| {
       $results = run_command(
@@ -481,7 +492,7 @@ plan puppetsync(
     # --------------------------------------------------------------------------
     'ensure_github_pr',
     # --------------------------------------------------------------------------
-    $opts
+    $opts + { 'skip_unchanged_targets' => true }
   ) |$ok_repos, $stage_name| {
     $ok_repos.map |$repo| {
       $results = run_task( 'puppetsync::ensure_github_pr', $repo,

--- a/dist/puppetsync/plans/init.pp
+++ b/dist/puppetsync/plans/init.pp
@@ -367,7 +367,7 @@ plan puppetsync(
     # Flag repos that needed no changes so later stages can skip them
     # (see 'skip_unchanged_targets' in puppetsync::pipeline_stage)
     $ok_repos.each |$repo| {
-      $result = $results.filter |$r| { $r.target.name == $repo.name }[0]
+      $result = $results.find($repo.name)
       if $result and $result.ok and $result.value['changed'] == false {
         $repo.set_var('puppetsync_unchanged', true)
         out::message( "-- ${repo.name}: no changes to commit; skipping GitHub stages" )

--- a/dist/puppetsync/tasks/checkout_git_feature_branch_in_each_repo.rb
+++ b/dist/puppetsync/tasks/checkout_git_feature_branch_in_each_repo.rb
@@ -8,8 +8,12 @@ def checkout_modules_to_branch(branch, repo_paths)
     status = 'created'
     Dir.chdir dir
     warn "== #{dir}"
-    `git branch --contains #{branch} &> /dev/null`
-    if $CHILD_STATUS.success?
+    # NOTE: no shell here — the old backticks + `&> /dev/null` silently always
+    # "succeeded" on systems where /bin/sh is not bash (dash parses `&>` as
+    # backgrounding), making every checkout take the branch-exists path
+    branch_exists = system('git', 'rev-parse', '--verify', '--quiet', "refs/heads/#{branch}",
+                           out: File::NULL, err: File::NULL)
+    if branch_exists
       status = 'checked_out'
       warn "NOTICE: branch '#{branch}' already exists; checking it out"
       pid = spawn 'git', 'checkout', branch, '-q'

--- a/dist/puppetsync/tasks/git_commit.json
+++ b/dist/puppetsync/tasks/git_commit.json
@@ -1,5 +1,5 @@
 {
-  "description": "Commit current changes in a git repo",
+  "description": "Commit current changes in a git repo (idempotent: returns changed=false when there is nothing to commit; amends when re-running with the same commit message)",
   "input_method": "stdin",
   "parameters": {
     "repo_path": {

--- a/dist/puppetsync/tasks/git_commit.rb
+++ b/dist/puppetsync/tasks/git_commit.rb
@@ -10,22 +10,34 @@ def git(*args)
   out
 end
 
+# `git diff --cached --quiet` exits 0 when nothing is staged and 1 when
+# something is; anything else is a real error and must not be misread
+def staged_changes?
+  out, status = Open3.capture2e('git', 'diff', '--cached', '--quiet')
+  case status.exitstatus
+  when 0 then false
+  when 1 then true
+  else raise("ERROR: 'git diff --cached --quiet' failed in #{Dir.pwd}:\n#{out}")
+  end
+end
+
 def git_commit(repo_path, commit_message)
   Dir.chdir repo_path
 
   warn "NOTICE: Running 'git add -A' in #{repo_path}"
   git('add', '-A')
 
-  # `git diff --cached --quiet` exits 0 when nothing is staged
-  if system('git', 'diff', '--cached', '--quiet')
+  unless staged_changes?
     warn "== #{File.basename(repo_path)} : nothing to commit in #{repo_path}"
     return { 'changed' => false }
   end
 
   # Amend instead of piling up commits when re-running the same session
   # (compare with trailing whitespace stripped: `git log --pretty=%B` output
-  # carries trailing newlines that the commit_message parameter may not have)
-  amend = git('log', '-1', '--pretty=%B').rstrip == commit_message.rstrip
+  # carries trailing newlines that the commit_message parameter may not have).
+  # A repo with no commits yet has no HEAD to compare — never amend there.
+  head_message, head_status = Open3.capture2e('git', 'log', '-1', '--pretty=%B')
+  amend = head_status.success? && head_message.rstrip == commit_message.rstrip
 
   Tempfile.create('commit_msg_file') do |commit_msg_file|
     commit_msg_file.write(commit_message)

--- a/dist/puppetsync/tasks/git_commit.rb
+++ b/dist/puppetsync/tasks/git_commit.rb
@@ -1,37 +1,44 @@
 #!/opt/puppetlabs/bolt/bin/ruby
 
 require 'json'
+require 'open3'
 require 'tempfile'
-require 'English'
+
+def git(*args)
+  out, status = Open3.capture2e('git', *args)
+  raise("ERROR: 'git #{args.join(' ')}' failed in #{Dir.pwd}:\n#{out}") unless status.success?
+  out
+end
 
 def git_commit(repo_path, commit_message)
-  commit_msg_file = Tempfile.new('commit_msg_file')
-  begin
-    commit_msg_file.write(commit_message)
-    commit_msg_file.close
+  Dir.chdir repo_path
 
-    Dir.chdir repo_path
-    warn "NOTICE: Running 'git add  -A' in #{repo_path}"
-    pid = spawn 'git', 'add', '-A'
-    Process.wait pid
+  warn "NOTICE: Running 'git add -A' in #{repo_path}"
+  git('add', '-A')
 
-    current_commit = `git log -1 --pretty=%B`.chomp
-    if current_commit == commit_message
-      warn "NOTICE: Running 'git commit -F #{commit_msg_file.path} --amend' in #{repo_path}"
-      pid = spawn 'git', 'commit', '-F', commit_msg_file.path, '--amend'
-      Process.wait pid
-    else
-      warn "NOTICE: Running 'git commit -F #{commit_msg_file.path}' in #{repo_path}"
-      pid = spawn 'git', 'commit', '-F', commit_msg_file.path
-      Process.wait pid
-    end
-    if $CHILD_STATUS.success?
-      puts "== #{File.basename(repo_path)} : committed changes in #{repo_path}"
-    end
-  ensure
-    commit_msg_file.close
-    commit_msg_file.unlink
+  # `git diff --cached --quiet` exits 0 when nothing is staged
+  if system('git', 'diff', '--cached', '--quiet')
+    warn "== #{File.basename(repo_path)} : nothing to commit in #{repo_path}"
+    return { 'changed' => false }
   end
+
+  # Amend instead of piling up commits when re-running the same session
+  # (compare with trailing whitespace stripped: `git log --pretty=%B` output
+  # carries trailing newlines that the commit_message parameter may not have)
+  amend = git('log', '-1', '--pretty=%B').rstrip == commit_message.rstrip
+
+  Tempfile.create('commit_msg_file') do |commit_msg_file|
+    commit_msg_file.write(commit_message)
+    commit_msg_file.flush
+
+    args = ['commit', '-F', commit_msg_file.path]
+    args << '--amend' if amend
+    warn "NOTICE: Running 'git #{args.join(' ')}' in #{repo_path}"
+    git(*args)
+  end
+
+  warn "== #{File.basename(repo_path)} : committed changes in #{repo_path}"
+  { 'changed' => true, 'amended' => amend }
 end
 
 stdin = STDIN.read
@@ -40,4 +47,4 @@ warn stdin
 
 raise('No repo path given') unless params['repo_path']
 raise('No commit_message given') unless params['commit_message']
-git_commit(params['repo_path'], params['commit_message'])
+puts JSON.generate(git_commit(params['repo_path'], params['commit_message']))

--- a/scripts/ci-e2e-idempotency.sh
+++ b/scripts/ci-e2e-idempotency.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# End-to-end test for puppetsync idempotency (#49).
+#
+# Runs the sync plan twice against a local file:// fixture repo:
+#   - run 1 commits a change (drop_glci_config removes the fixture's
+#     .gitlab-ci.yml) and must report "1 ok"
+#   - run 2 has nothing to do and must report "1 unchanged", skipping the
+#     GitHub fork/remote/push/PR stages. Those stages are enabled for run 2
+#     with dummy tokens and no git remotes configured, so if the
+#     skip-unchanged filter ever breaks, they fail loudly.
+#
+# Requires bolt (openbolt) and the project's modules (./Rakefile install).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BOLT="${BOLT:-/opt/puppetlabs/bolt/bin/bolt}"
+export BOLT_DISABLE_ANALYTICS=true
+export GITHUB_API_TOKEN="${GITHUB_API_TOKEN:-dummy}"
+export GITLAB_API_TOKEN="${GITLAB_API_TOKEN:-dummy}" # required until #51 merges
+export GIT_AUTHOR_NAME='puppetsync e2e' GIT_AUTHOR_EMAIL='e2e@example.com'
+export GIT_COMMITTER_NAME='puppetsync e2e' GIT_COMMITTER_EMAIL='e2e@example.com'
+
+WORK="$(mktemp -d)"
+CONFIG=data/sync/configs/zz-ci-e2e.yaml
+REPOLIST=data/sync/repolists/zz-ci-e2e.yaml
+trap 'rm -rf "$WORK" "$CONFIG" "$REPOLIST" _repos/fixture-repo.git' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- fixture upstream: one repo with a .gitlab-ci.yml to drop ---------------
+git init -q -b main "$WORK/seed"
+git -C "$WORK/seed" config user.email e2e@example.com
+git -C "$WORK/seed" config user.name 'puppetsync e2e'
+echo hello > "$WORK/seed/README.md"
+printf 'stages:\n  - old\n' > "$WORK/seed/.gitlab-ci.yml"
+git -C "$WORK/seed" add -A
+git -C "$WORK/seed" commit -qm seed
+git clone -q --bare "$WORK/seed" "$WORK/fixture-repo.git"
+
+# --- session config/repolist -------------------------------------------------
+cat > "$CONFIG" <<'YAML'
+---
+puppetsync::plan_config:
+  puppetsync:
+    permitted_project_types: []
+    plans:
+      sync:
+        filter_permitted_repos: false
+        stages:
+          - checkout_git_feature_branch_in_each_repo
+          - drop_glci_config
+          - git_commit_changes
+  git:
+    feature_branch: TEST-9999
+    commit_message: |
+      (TEST-9999) ci e2e idempotency test for %COMPONENT%
+YAML
+
+cat > "$REPOLIST" <<YAML
+---
+puppetsync::repos_config:
+  file://$WORK/fixture-repo.git:
+    branch: main
+YAML
+
+# --- run 1: expect a commit --------------------------------------------------
+echo '== run 1 (expect: 1 ok)'
+OUT1="$("$BOLT" plan run puppetsync config=zz-ci-e2e repolist=zz-ci-e2e 2>&1)" \
+  || { echo "$OUT1"; fail 'run 1 exited nonzero'; }
+grep -q '1 ok / 0 unchanged / 0 failed' <<<"$OUT1" \
+  || { echo "$OUT1"; fail 'run 1 did not report "1 ok / 0 unchanged / 0 failed"'; }
+
+# --- run 2: expect unchanged + GitHub stages skipped -------------------------
+echo '== run 2 (expect: 1 unchanged, GitHub stages skipped)'
+RUN2_STAGES='["checkout_git_feature_branch_in_each_repo","drop_glci_config","git_commit_changes","ensure_github_fork","ensure_git_remote","git_push_to_remote","ensure_github_pr"]'
+OUT2="$("$BOLT" plan run puppetsync config=zz-ci-e2e repolist=zz-ci-e2e \
+  options="{\"clone_git_repos\": false, \"stages\": $RUN2_STAGES}" 2>&1)" \
+  || { echo "$OUT2"; fail 'run 2 exited nonzero'; }
+grep -q '0 ok / 1 unchanged / 0 failed' <<<"$OUT2" \
+  || { echo "$OUT2"; fail 'run 2 did not report "0 ok / 1 unchanged / 0 failed"'; }
+for stage in ensure_github_fork ensure_git_remote git_push_to_remote ensure_github_pr; do
+  grep -q "SKIPPING 1 UNCHANGED TARGET(S) FOR STAGE: $stage" <<<"$OUT2" \
+    || { echo "$OUT2"; fail "run 2 did not skip stage $stage"; }
+done
+
+echo 'PASS: e2e idempotency test'

--- a/spec/tasks/checkout_git_feature_branch_spec.rb
+++ b/spec/tasks/checkout_git_feature_branch_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'task: checkout_git_feature_branch_in_each_repo' do
+  def git(*args)
+    out, status = Open3.capture2e('git', '-C', @repo, *args)
+    raise "git #{args.join(' ')} failed:\n#{out}" unless status.success?
+    out
+  end
+
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      @repo = dir
+      git('init', '-b', 'main')
+      git('config', 'user.email', 'ci@example.com')
+      git('config', 'user.name', 'CI')
+      File.write(File.join(@repo, 'README.md'), "hello\n")
+      git('add', '-A')
+      git('commit', '-m', 'initial')
+      example.run
+    end
+  end
+
+  def run_checkout(branch)
+    run_task('checkout_git_feature_branch_in_each_repo.rb', 'branch' => branch, 'repo_paths' => [@repo])
+  end
+
+  it 'creates the feature branch when it does not exist' do
+    stdout, stderr, status = run_checkout('SIMP-0000')
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq(@repo => 'created')
+    expect(git('branch', '--show-current').strip).to eq('SIMP-0000')
+  end
+
+  it 'checks out the feature branch when it already exists' do
+    git('branch', 'SIMP-0000')
+
+    stdout, stderr, status = run_checkout('SIMP-0000')
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq(@repo => 'checked_out')
+    expect(git('branch', '--show-current').strip).to eq('SIMP-0000')
+  end
+
+  it 'fails when no branch is given' do
+    _stdout, _stderr, status = run_task('checkout_git_feature_branch_in_each_repo.rb', 'repo_paths' => [@repo])
+    expect(status).not_to be_success
+  end
+end

--- a/spec/tasks/git_commit_spec.rb
+++ b/spec/tasks/git_commit_spec.rb
@@ -20,39 +20,67 @@ describe 'task: git_commit' do
     end
   end
 
-  it 'commits pending changes with the given message' do
+  it 'commits pending changes and reports changed: true' do
     File.write(File.join(@repo, 'new_file'), "content\n")
 
-    _stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'add new file')
+    stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'add new file')
 
     expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('changed' => true, 'amended' => false)
     expect(git('log', '-1', '--pretty=%s').strip).to eq('add new file')
     expect(git('status', '--porcelain')).to be_empty
   end
 
-  it 'amends the HEAD commit when the message matches' do
-    # Production commit messages are multi-line templates ending in a newline;
-    # the task's amend detection compares against `git log -1 --pretty=%B`.
+  it 'amends the HEAD commit when a multi-line message matches' do
     message = "(SIMP-1234) update baseline\n\ndetails\n"
 
     File.write(File.join(@repo, 'first'), "a\n")
     run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => message)
 
     File.write(File.join(@repo, 'second'), "b\n")
-    _stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => message)
+    stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => message)
 
     expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('changed' => true, 'amended' => true)
     expect(git('rev-list', '--count', 'HEAD').strip).to eq('2') # initial + one amended commit
     expect(git('ls-tree', '--name-only', 'HEAD').split).to include('first', 'second')
   end
 
-  it 'exits cleanly and leaves HEAD alone when there is nothing to commit' do
-    head_before = git('rev-parse', 'HEAD')
+  it 'amends the HEAD commit when a single-line message matches' do
+    File.write(File.join(@repo, 'first'), "a\n")
+    run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'single-line message')
 
-    _stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'no-op run')
+    File.write(File.join(@repo, 'second'), "b\n")
+    stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'single-line message')
 
     expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('changed' => true, 'amended' => true)
+    expect(git('rev-list', '--count', 'HEAD').strip).to eq('2')
+  end
+
+  it 'reports changed: false and leaves HEAD alone when there is nothing to commit' do
+    head_before = git('rev-parse', 'HEAD')
+
+    stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => 'no-op run')
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('changed' => false)
     expect(git('rev-parse', 'HEAD')).to eq(head_before)
+  end
+
+  it 'fails when the commit itself fails' do
+    File.write(File.join(@repo, 'new_file'), "content\n")
+
+    # An empty commit message makes `git commit` abort
+    _stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => @repo, 'commit_message' => "\n")
+
+    expect(status).not_to be_success
+    expect(stderr).to include('failed')
+  end
+
+  it 'fails when repo_path does not exist' do
+    _stdout, _stderr, status = run_task('git_commit.rb', 'repo_path' => '/nonexistent/path', 'commit_message' => 'x')
+    expect(status).not_to be_success
   end
 
   it 'fails when repo_path is missing' do

--- a/spec/tasks/git_commit_spec.rb
+++ b/spec/tasks/git_commit_spec.rb
@@ -68,6 +68,23 @@ describe 'task: git_commit' do
     expect(git('rev-parse', 'HEAD')).to eq(head_before)
   end
 
+  it 'commits normally in a repo with no commits yet (no HEAD to amend)' do
+    Dir.mktmpdir do |empty_repo|
+      out, status = Open3.capture2e('git', '-C', empty_repo, 'init', '-b', 'main')
+      raise out unless status.success?
+      Open3.capture2e('git', '-C', empty_repo, 'config', 'user.email', 'ci@example.com')
+      Open3.capture2e('git', '-C', empty_repo, 'config', 'user.name', 'CI')
+      File.write(File.join(empty_repo, 'first_file'), "content\n")
+
+      stdout, stderr, status = run_task('git_commit.rb', 'repo_path' => empty_repo, 'commit_message' => 'first commit')
+
+      expect(status).to be_success, stderr
+      expect(JSON.parse(stdout)).to eq('changed' => true, 'amended' => false)
+      count, = Open3.capture2e('git', '-C', empty_repo, 'rev-list', '--count', 'HEAD')
+      expect(count.strip).to eq('1')
+    end
+  end
+
   it 'fails when the commit itself fails' do
     File.write(File.join(@repo, 'new_file'), "content\n")
 


### PR DESCRIPTION
Closes #49

puppetsync could not safely run against a repo that needed no changes: `git_commit.rb` ignored git's exit status entirely, so a no-change repo "passed" the commit stage silently, force-pushed an empty branch, and failed at `ensure_github_pr` with Octokit's `422 "No commits between base and head"`. Real commit failures were swallowed the same way.

## Changes

**`git_commit` task — honest and idempotent**
- After `git add -A`, checks `git diff --cached --quiet`: clean → returns `{changed: false}` and exits 0; dirty → commits and returns `{changed: true, amended: <bool>}`
- Real `git` failures now raise (previously the exit status was only used to decide whether to print a notice)
- Amend detection compares messages with trailing whitespace stripped, fixing the quirk noted in #64's review trail: it never fired for single-line messages (`git log -1 --pretty=%B` keeps trailing newlines)

**Pipeline wiring — unchanged ≠ failed**
- The `git_commit_changes` stage sets a `puppetsync_unchanged` var on no-change targets
- `puppetsync::pipeline_stage` gains a `skip_unchanged_targets` option; the `ensure_github_fork`, `ensure_git_remote`, `git_push_to_remote`, and `ensure_github_pr` stages enable it, so unchanged repos skip the GitHub stages while staying "ok"

**Three-bucket summary**
- The results table shows per-repo `ok` / `unchanged` / `failed`, and the run ends with a `N ok / N unchanged / N failed (N total)` line

## Verification

- **End-to-end** against a local `file://` fixture repo (temporary config/repolist, not committed), stages: checkout → `drop_glci_config` → commit → the four GitHub stages:
  - Run 1: commits the change on the feature branch → `1 ok / 0 unchanged / 0 failed`
  - Run 2 (`clone_git_repos: false`): `no changes to commit`, all four GitHub stages log `SKIPPING 1 UNCHANGED TARGET(S)`, HEAD untouched, plan exits successfully → `0 ok / 1 unchanged / 0 failed`. With dummy tokens and no git remotes configured, any GitHub stage that actually ran would have failed — passing proves the filter works.
- **Unit**: `spec/tasks/git_commit_spec.rb` updated for the new contract (JSON output, single-line amend, no-op safety, failure propagation on bad message/missing repo) — 142 examples, 0 failures
- `bolt plan show puppetsync`, `puppet parser validate`, and the `list_pipeline_stages` dry run all green

## Notes

- This intentionally does not gate `ensure_gitlab_remote`/`git_push_to_gitlab` — those stages are removed entirely by #65, and leaving them untouched here keeps the two PRs conflict-free in either merge order.
- This is the keystone for #55 (dynamic GitHub-org inventory) and #56 (scheduled runs), where most repos in any given run will be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
