### PR TITLE
Fetch/reset existing clones instead of rm -rf + full re-clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Repo setup no longer wipes `_repos/` and re-clones everything on each run
+  (#53): existing matching clones are fetched and reset to origin's state by
+  the new `ensure_git_clone` task, which is much faster for large repolists.
+  Mismatched paths are replaced when `clear_before_clone` is true (the
+  default) and fail the run otherwise.
 - The `puppetsync` plan is now fully idempotent: repos that need no changes
   pass through cleanly instead of failing at the PR stage (#49)
   - The `git_commit` task reports `changed: false` when there is nothing to

--- a/dist/puppetsync/functions/setup_project_repos.pp
+++ b/dist/puppetsync/functions/setup_project_repos.pp
@@ -25,21 +25,25 @@ function puppetsync::setup_project_repos(
   warning( "\n\n==  \$puppetsync_config:\n${puppetsync_config.to_yaml.regsubst('^','    ','G')}" )
 
   if $opts['clone_git_repos'] {
-    $repos_dir = "${project_dir}/${opts['default_repo_moduledir']}"
-    if $opts['clear_before_clone'] {
-      $ruby_path = get_target('localhost').config['local']['interpreters']['.rb']
-      run_command(
-        "${ruby_path} -r fileutils -e 'FileUtils.mkdir_p \"${repos_dir}\"; FileUtils.rm_rf(Dir[\"${repos_dir}/*\"])'",
-        'localhost'
-      )
+    # Clone each repo, or — when a matching clone already exists — fetch and
+    # reset it to origin's state, which is much faster than re-cloning.
+    # Paths that exist but don't match their repo are replaced when
+    # `clear_before_clone` is true (the default), and fail the run otherwise.
+    $results = run_task_with('puppetsync::ensure_git_clone', $pf_repos, '_catch_errors' => false) |$t| {
+      {
+        'git_url'   => $t.vars['mod_data']['git_url'],
+        'repo_path' => $t.vars['repo_path'],
+        'branch'    => $t.vars['mod_data']['branch'],
+        'clear'     => $opts['clear_before_clone'],
+      }
     }
-    $result = parallelize($pf_repos) |$t| {
-      # FIXME should this blow away the old directory or git fetch/checkout?
-      # TODO make this a task with smarter behavior
-      $cmd = "git clone \"${t.vars['mod_data']['git_url']}\" \"${t.vars['repo_path']}\" -b \"${t.vars['mod_data']['branch']}\""
-      out::message($cmd)
-      run_command($cmd, $t)
-    }
+    $methods = $results.map |$r| { $r.value['method'] }
+    out::message( sprintf(
+      '== repos ready: %d cloned / %d updated / %d recloned',
+      $methods.filter |$x| { $x == 'cloned' }.size,
+      $methods.filter |$x| { $x == 'updated' }.size,
+      $methods.filter |$x| { $x == 'recloned' }.size,
+    ))
   } else {
     warning( '' )
     warning( '== WARNING: **NOT** cloning git repos because $opts["clone_git_repos"] = false!' )

--- a/dist/puppetsync/tasks/ensure_git_clone.json
+++ b/dist/puppetsync/tasks/ensure_git_clone.json
@@ -1,0 +1,22 @@
+{
+  "description": "Ensure a git clone exists at repo_path and matches origin's state. Existing matching clones are fetched and reset (much faster than re-cloning); mismatched paths are replaced when clear is true.",
+  "input_method": "stdin",
+  "parameters": {
+    "git_url": {
+      "description": "URL of the git repository to clone",
+      "type": "String[1]"
+    },
+    "repo_path": {
+      "description": "Path where the clone should exist",
+      "type": "String[1]"
+    },
+    "branch": {
+      "description": "Branch to check out (reset to origin's tip)",
+      "type": "String[1]"
+    },
+    "clear": {
+      "description": "When repo_path exists but is not a clone of git_url: true replaces it, false fails (default: true)",
+      "type": "Optional[Boolean]"
+    }
+  }
+}

--- a/dist/puppetsync/tasks/ensure_git_clone.rb
+++ b/dist/puppetsync/tasks/ensure_git_clone.rb
@@ -1,0 +1,70 @@
+#!/opt/puppetlabs/bolt/bin/ruby
+
+require 'fileutils'
+require 'json'
+require 'open3'
+
+def git(*args, chdir: nil)
+  cmd = ['git'] + args
+  opts = chdir ? { chdir: chdir } : {}
+  out, status = Open3.capture2e(*cmd, **opts)
+  raise("ERROR: '#{cmd.join(' ')}' failed#{chdir ? " in #{chdir}" : ''}:\n#{out}") unless status.success?
+  out
+end
+
+def existing_clone_matches?(repo_path, git_url)
+  return false unless File.directory?(File.join(repo_path, '.git'))
+
+  out, status = Open3.capture2e('git', 'remote', 'get-url', 'origin', chdir: repo_path)
+  status.success? && out.strip == git_url
+end
+
+# Bring an existing clone to the same state a fresh clone would have:
+# base branch at origin's tip, clean working tree, no leftover local branches
+def update_clone(repo_path, branch)
+  git('fetch', '--prune', 'origin', chdir: repo_path)
+  git('checkout', '-B', branch, "origin/#{branch}", chdir: repo_path)
+  # checkout -B carries over dirty tracked files; reset --hard discards them
+  git('reset', '--hard', "origin/#{branch}", chdir: repo_path)
+  git('clean', '-fdx', chdir: repo_path)
+
+  local_branches = git('for-each-ref', '--format=%(refname:short)', 'refs/heads', chdir: repo_path).split("\n")
+  (local_branches - [branch]).each { |stale| git('branch', '-D', stale, chdir: repo_path) }
+end
+
+def clone(git_url, repo_path, branch)
+  FileUtils.mkdir_p(File.dirname(repo_path))
+  git('clone', git_url, repo_path, '-b', branch)
+end
+
+def ensure_git_clone(git_url, repo_path, branch, clear)
+  if existing_clone_matches?(repo_path, git_url)
+    warn "== #{File.basename(repo_path)} : updating existing clone in #{repo_path}"
+    update_clone(repo_path, branch)
+    { 'method' => 'updated' }
+  elsif File.exist?(repo_path)
+    unless clear
+      raise("ERROR: '#{repo_path}' exists but is not a clone of '#{git_url}' " \
+            '(and clear_before_clone is false, so it will not be replaced)')
+    end
+    warn "== #{File.basename(repo_path)} : replacing '#{repo_path}' (not a clone of #{git_url})"
+    FileUtils.rm_rf(repo_path)
+    clone(git_url, repo_path, branch)
+    { 'method' => 'recloned' }
+  else
+    warn "== #{File.basename(repo_path)} : cloning #{git_url} into #{repo_path}"
+    clone(git_url, repo_path, branch)
+    { 'method' => 'cloned' }
+  end
+end
+
+stdin = STDIN.read
+params = JSON.parse(stdin)
+warn stdin
+
+raise('No git_url given') unless params['git_url']
+raise('No repo_path given') unless params['repo_path']
+raise('No branch given') unless params['branch']
+clear = params.fetch('clear', true)
+
+puts JSON.generate(ensure_git_clone(params['git_url'], params['repo_path'], params['branch'], clear))

--- a/spec/tasks/ensure_git_clone_spec.rb
+++ b/spec/tasks/ensure_git_clone_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe 'task: ensure_git_clone' do
+  def git(dir, *args)
+    out, status = Open3.capture2e('git', '-C', dir, *args)
+    raise "git #{args.join(' ')} failed:\n#{out}" unless status.success?
+    out
+  end
+
+  # A local "upstream": a seed working repo pushed into a bare repo
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      @seed = File.join(dir, 'seed')
+      @upstream = File.join(dir, 'upstream.git')
+      @clone = File.join(dir, 'repos', 'myrepo')
+
+      FileUtils.mkdir_p(@seed)
+      git(@seed, 'init', '-q', '-b', 'main')
+      git(@seed, 'config', 'user.email', 'ci@example.com')
+      git(@seed, 'config', 'user.name', 'CI')
+      File.write(File.join(@seed, 'README.md'), "hello\n")
+      git(@seed, 'add', '-A')
+      git(@seed, 'commit', '-qm', 'initial')
+      git(@seed, 'clone', '-q', '--bare', @seed, @upstream)
+
+      example.run
+    end
+  end
+
+  def run_clone_task(extra = {})
+    run_task('ensure_git_clone.rb',
+             { 'git_url' => @upstream, 'repo_path' => @clone, 'branch' => 'main' }.merge(extra))
+  end
+
+  def upstream_commit(message)
+    File.write(File.join(@seed, message), "#{message}\n")
+    git(@seed, 'add', '-A')
+    git(@seed, 'commit', '-qm', message)
+    git(@seed, 'push', '-q', @upstream, 'main')
+  end
+
+  it 'clones fresh when the path does not exist' do
+    stdout, stderr, status = run_clone_task
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('method' => 'cloned')
+    expect(File).to exist(File.join(@clone, 'README.md'))
+  end
+
+  it 'fetches and resets an existing matching clone to origin state' do
+    run_clone_task
+    upstream_commit('new-upstream-file')
+
+    # Local noise a previous session could leave behind
+    git(@clone, 'checkout', '-q', '-b', 'OLD-SESSION-123')
+    File.write(File.join(@clone, 'dirty-untracked'), "x\n")
+    File.write(File.join(@clone, 'README.md'), "modified\n")
+
+    stdout, stderr, status = run_clone_task
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('method' => 'updated')
+    expect(git(@clone, 'rev-parse', 'HEAD')).to eq(git(@seed, 'rev-parse', 'HEAD'))
+    expect(git(@clone, 'branch', '--show-current').strip).to eq('main')
+    expect(git(@clone, 'for-each-ref', '--format=%(refname:short)', 'refs/heads').split).to eq(['main'])
+    expect(File).not_to exist(File.join(@clone, 'dirty-untracked'))
+    expect(File.read(File.join(@clone, 'README.md'))).to eq("hello\n")
+  end
+
+  it 'is idempotent when origin has not changed' do
+    run_clone_task
+    head_before = git(@clone, 'rev-parse', 'HEAD')
+
+    stdout, _stderr, status = run_clone_task
+
+    expect(status).to be_success
+    expect(JSON.parse(stdout)).to eq('method' => 'updated')
+    expect(git(@clone, 'rev-parse', 'HEAD')).to eq(head_before)
+  end
+
+  it 'replaces a mismatched path when clear is true' do
+    FileUtils.mkdir_p(@clone)
+    File.write(File.join(@clone, 'not-a-repo'), "junk\n")
+
+    stdout, stderr, status = run_clone_task('clear' => true)
+
+    expect(status).to be_success, stderr
+    expect(JSON.parse(stdout)).to eq('method' => 'recloned')
+    expect(File).not_to exist(File.join(@clone, 'not-a-repo'))
+    expect(File).to exist(File.join(@clone, 'README.md'))
+  end
+
+  it 'fails on a mismatched path when clear is false' do
+    FileUtils.mkdir_p(@clone)
+    File.write(File.join(@clone, 'not-a-repo'), "junk\n")
+
+    _stdout, stderr, status = run_clone_task('clear' => false)
+
+    expect(status).not_to be_success
+    expect(stderr).to include('not a clone')
+    expect(File).to exist(File.join(@clone, 'not-a-repo'))
+  end
+
+  it 'fails when required params are missing' do
+    _stdout, _stderr, status = run_task('ensure_git_clone.rb', 'repo_path' => @clone)
+    expect(status).not_to be_success
+  end
+end


### PR DESCRIPTION
Closes #53

`setup_project_repos` wiped `_repos/*` and fully re-cloned every repo on every run (`clear_before_clone` defaulted to a global `rm -rf`). That's painfully slow when iterating on a session, and it's the code carrying the long-standing `FIXME should this blow away the old directory or git fetch/checkout?` / `TODO make this a task with smarter behavior` comments — this PR resolves both.

## Changes

**New `ensure_git_clone` task** (standalone Ruby, unit-testable like the rest):
- Path exists and `origin` matches `git_url` → **update**: `fetch --prune`, `checkout -B <branch> origin/<branch>`, `reset --hard`, `clean -fdx`, and prune stale local branches — ending in exactly the state a fresh clone would produce, without the transfer
- Path missing → **clone**
- Path exists but doesn't match (or isn't a git repo) → **reclone** when `clear` is true, hard failure when false

**`setup_project_repos`** replaces the global `rm -rf` + `parallelize`d `git clone` with a `run_task_with` over the repo targets (per-target params, concurrent under Bolt's normal concurrency), and reports `N cloned / N updated / N recloned`.

## Semantics notes

- `clear_before_clone` keeps its spirit with a sharper meaning: it now governs only *mismatched* paths (replace vs. fail) rather than triggering a blanket wipe. `clone_git_repos: false` is untouched.
- One behavior difference from the old wipe: directories in `_repos/` belonging to repos *not* in the current repolist are left in place instead of being deleted. They're inert (targets come only from the repolist); `rake clobber` still removes the whole directory.

## Verification

- **Unit** (`spec/tasks/ensure_git_clone_spec.rb`, against local bare-repo fixtures): fresh clone, fetch/reset to origin state (dirty tracked files discarded, untracked/ignored files cleaned, stale session branches pruned, HEAD matching upstream after an upstream commit), idempotent re-run, mismatch handling for both `clear` values, and param validation — 147 examples, 0 failures overall.
- **End-to-end** with a `file://` fixture and a temporary config (not committed): run 1 → `1 cloned / 0 updated / 0 recloned`; then an upstream commit plus deliberate local leftovers (session feature branch with a commit); run 2 → `0 cloned / 1 updated / 0 recloned`, the upstream commit present, and the feature branch recreated fresh on the updated base.
- `bolt plan show`, `puppet parser validate`, and the `list_pipeline_stages` dry run all green.

Found during testing (worth knowing): `git checkout -B` carries dirty tracked files across the branch reset — the explicit `reset --hard` in the update path is load-bearing, and there's a regression test pinning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
